### PR TITLE
Fix memory leak in tensor override parser

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2344,8 +2344,9 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
                     }
                     throw std::invalid_argument("unknown buffer type");
                 }
-                // FIXME: this leaks memory
-                params.tensor_buft_overrides.push_back({strdup(tensor_name.c_str()), buft_list.at(buffer_type)});
+                // store pattern to ensure lifetime for the C-string
+                params.tensor_buft_override_names.push_back(tensor_name);
+                params.tensor_buft_overrides.push_back({params.tensor_buft_override_names.back().c_str(), buft_list.at(buffer_type)});
             }
         }
     ));

--- a/common/common.h
+++ b/common/common.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+#include <deque>
 #include <sstream>
 
 #ifdef _WIN32
@@ -281,6 +282,7 @@ struct common_params {
     std::vector<std::string> in_files;   // all input files
     std::vector<std::string> antiprompt; // strings upon which more user input is prompted (a.k.a. reverse prompts)
     std::vector<llama_model_kv_override> kv_overrides;
+    std::deque<std::string> tensor_buft_override_names; // storage for tensor override patterns
     std::vector<llama_model_tensor_buft_override> tensor_buft_overrides;
 
     bool lora_init_without_apply = false; // only load lora to memory, but do not apply it to ctx (user can manually apply lora later using llama_adapter_lora_apply)


### PR DESCRIPTION
## Summary
- store tensor buffer override strings in deque to avoid leaks
- reference these stable strings when building tensor buffer overrides

## Testing
- `g++ -std=c++17 -Iinclude -I. -Iggml/include -c common/arg.cpp`